### PR TITLE
Add E2E testing for page load

### DIFF
--- a/cypress/e2e/main-spec.cy.js
+++ b/cypress/e2e/main-spec.cy.js
@@ -1,0 +1,32 @@
+describe('Main Spec', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'http://localhost:3001/api/v1/reservations', {
+      statusCode: 200,
+      fixture: 'sampleData'
+    }).as('sampleData')
+  })
+  it('Page load tests', () => {
+    cy.visit('http://localhost:3000/')
+    cy.wait('@sampleData')
+    cy.get('.app-title').should('contain', 'Turing Cafe Reservations')
+    cy.get('.resy-form').should('exist')
+    .get('[placeholder="Name"]').should('exist')
+    .get('[type="date"]').should('exist')
+    .get('[type="time"]').should('exist')
+    .get('[placeholder="Number of Guests"]').should('exist')
+    .get('form > button').should('exist')
+    cy.get('.resy-container').should('exist')
+    .children().should('contain', 4)
+  })
+
+  it('Form tests', () => {
+    cy.visit('http://localhost:3000/')
+    cy.wait('@sampleData')
+  })
+
+  it('Add new reservation user flow', () => {
+    cy.visit('http://localhost:3000/')
+    cy.wait('@sampleData')
+  })
+
+})

--- a/cypress/fixtures/sampleData.json
+++ b/cypress/fixtures/sampleData.json
@@ -1,0 +1,30 @@
+[
+    {
+    "id": 1,
+    "name": "Christie",
+    "date": "12/29",
+    "time": "7:00",
+    "number": 12
+    },
+    {
+    "id": 2,
+    "name": "Leta",
+    "date": "4/5",
+    "time": "7:00",
+    "number": 2
+    },
+    {
+    "id": 3,
+    "name": "Pam",
+    "date": "1/21",
+    "time": "6:00",
+    "number": 4
+    },
+    {
+    "id": 4,
+    "name": "Khalid",
+    "date": "5/9",
+    "time": "7:30",
+    "number": 7
+    }
+]


### PR DESCRIPTION
## What I did:
- Add cypress testing for main page load
- Add beforeEach to intercept GET request
- Added fixture for main-spec intercept

## Notes:

### Did this break anything?

- [x] No
- [ ]  Yes

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.


### Contributors to this pull request:
